### PR TITLE
Fix resolver conflict + Fix property checks of object

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -40,7 +40,7 @@ class Parser {
 
     tokenize($context);
     analyze($context);
-    resolve($context);
+    resolveFromContext($context);
 
     $context->document = new Section($context, $context->document_instruction);
 

--- a/src/analyzer.php
+++ b/src/analyzer.php
@@ -230,11 +230,11 @@ function analyze(stdClass $context) : void {
       $last_section_instruction = $instruction;
       $active_section_instructions[] = $instruction;
 
-      if(array_key_exists('template', $instruction)) {
+      if(property_exists($instruction, 'template')) {
         $context->unresolved_instructions[] = $instruction;
       }
 
-      if(!array_key_exists('template', $instruction) || $instruction->name !== $instruction->template) {
+      if(!property_exists($instruction, 'template') || $instruction->name !== $instruction->template) {
         if(array_key_exists($instruction->name, $context->template_index)) {
           $context->template_index[$instruction->name][] = $instruction;
         } else {

--- a/src/elements/Field.php
+++ b/src/elements/Field.php
@@ -26,7 +26,7 @@ class Field {
 
     $instruction->element = $this;
 
-    if($instruction->type === 'BLOCK' && array_key_exists('content_range', $instruction)) {
+    if($instruction->type === 'BLOCK' && property_exists($instruction, 'content_range')) {
       $this->value = substr(
         $context->input,
         $instruction->content_range[0],

--- a/src/resolver.php
+++ b/src/resolver.php
@@ -262,7 +262,7 @@ function recursiveResolve(stdClass $context, stdClass $instruction, array $previ
   }
 }
 
-function resolve(stdClass $context) : void {
+function resolveFromContext(stdClass $context) : void {
   while(count($context->unresolved_instructions) > 0) {
     recursiveResolve($context, $context->unresolved_instructions[0]);
   }


### PR DESCRIPTION
This PR resolves an issue with the conflicting Laravel `resolve` global function and fixes some object checking using the `property_exists` instead of `array_key_exists` function since it doesn't support objects anymore in later PHP versions.

There are more places that use `array_key_exists` that need to be adjusted to fully support all features of this great library with newer PHP versions. Once I have some time I'll tend to them and create another PR.

But anyways. Let me know what you think.

One last thing. Really great package and superb idea. Loving it so much. Now all the email templates that we use across the platform are structured in a cleaner manner and are easier to maintain.